### PR TITLE
Rename functions for better understanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Convert between various channel id formats in Lightning network.
 
 npm install @synonymdev/lightning-channel-id
 
-const {clnToLnd, lndToCln} = require("lightning-channel-js")
+const {fromCln, fromLnd} = require("lightning-channel-js")
 
-lndToCln("807896954914930688")
-clnToLnd("734778:1235:0")
+fromLnd("807896954914930688")
+fromCln("734778:1235:0")
 
 // All of the above should output same result
 {
@@ -26,14 +26,14 @@ clnToLnd("734778:1235:0")
 
 ### Functions
 
-### `lndToCln(channelId : String)`
+### `fromLnd(channelId : String)`
 Converts from LND format to CLN format
 
-### `clnToLnd(channelId : String, marker: String)`
+### `fromCln(channelId : String, marker: String)`
 Converts from CLN to LND format. 
 Accepts an optional `marker` string, which is used incase your channel format has a different seperator
 ```
-clnToLnd("734778x1235x0","x")
+fromCln("734778x1235x0","x")
 
 {
   block: '734778',

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const long = require("long")
  * @param {string} marker The character seperating between the items.
  * @returns {Object}
  */
-function clnToLnd(chanId, marker){
+function fromCln(chanId, marker){
   if(typeof chanId !== "string") throw new Error("Channel id must be string")
   const chid = chanId.split(marker || ":")
   if(chid.length !== 3) throw new Error("Invalid channel id passed")
@@ -23,7 +23,7 @@ function clnToLnd(chanId, marker){
   const tx = long.fromString(chid[1]).shiftLeft(16)
   const output = chid[2]
   const lnd = block.or(tx).or(output)
-  const fmt = lndToCln(lnd.toString())
+  const fmt = fromLnd(lnd.toString())
   fmt.cln_format = chanId
   return fmt
 }
@@ -33,7 +33,7 @@ function clnToLnd(chanId, marker){
  * @param {String} chanId Channel id in LND notation (uint64 string)
  * @returns {Object}
  */
-function lndToCln(chanId){
+function fromLnd(chanId){
   const block = long.fromString(chanId).shiftRight(40)
   const tx = long.fromString(chanId).shiftRight(16).and(0xFFFFFF)
   const output = long.fromString(chanId).and(0xFFFF)
@@ -48,6 +48,6 @@ function lndToCln(chanId){
 
 
 module.exports = {
-  clnToLnd,
-  lndToCln,
+  fromCln,
+  fromLnd,
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
 'use strict'
 const assert = require('assert')
-const {clnToLnd, lndToCln} = require("../index")
+const {fromCln, fromLnd} = require("../index")
 
 describe('Channel format converter', () => {
 
   it("should convert CLN format to LND format",()=>{
-      const scid = clnToLnd("734778:1235:0")
+      const scid = fromCln("734778:1235:0")
       assert(scid.lnd_format === "807896954914930688")
       assert(scid.tx === "1235")
       assert(scid.block ==="734778")
@@ -16,7 +16,7 @@ describe('Channel format converter', () => {
 
   it("should convert CLN format with a marker to LND format",()=>{
 
-    const scid = clnToLnd("734778x1235x0","x")
+    const scid = fromCln("734778x1235x0","x")
     assert(scid.lnd_format === "807896954914930688")
     assert(scid.tx === "1235")
     assert(scid.block === "734778")
@@ -25,7 +25,7 @@ describe('Channel format converter', () => {
   })
 
   it("should convert LND format to CLN format",()=>{
-    const scid = lndToCln("770826920361984001")
+    const scid = fromLnd("770826920361984001")
     assert(scid.lnd_format === "770826920361984001")
     assert(scid.tx === "892")
     assert(scid.block === "701063")


### PR DESCRIPTION
I think function names are wrong named according to me. It's more clear by naming them to `fromCln` and `fromLnd` because they return a generic format (including both cln and lnd format) 